### PR TITLE
feat/scrape and prep data model :sparkle: 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+test

--- a/README.md
+++ b/README.md
@@ -3,31 +3,32 @@ EnTemp displays average daily temperatures and agregates for January - October 2
 The data is sourced from the National Oceanic Atmospheric Administration. 
 It is a Django app that can be run either locally or with Docker.
 
+Current installation assumes you have Python3 and Pip installed locally.
 ## Docker Instructions
-	Install Docker, Docker-Compose, Python, Pip 
-	`docker-compose up`
+	Install Docker, Docker-Compose 
+	Spin up container: `docker-compose up`
 	
-	IF you add additional packages to the README you'll need to rebuild the contianer with: 
+	If you add additional packages to the README you'll need to rebuild the contianer with: 
 	`docker-compose build`
 	
 ## Local Instructions
 	`pip install -r requirements.txt`
+	`python manage.py runserver 0.0.0.0:8000`
 	
 With either set of instructions you will be able to go to `[localhost:8000](localhost:8000)` and see the `EnTempView`
 
 ## Backlog ##
 ### TODO ###
-- Scrape the data from the site.
-	- Use Actual Django Model? 
 - Build a TemperatureTemplate.
-	- Add Average Temperature Column.
-	- Add average aggregate Column.
-	- Add standard deviation aggregate Column.
+- Look at performance of the scraper by converting to pure lxml.
+- Use Actual Django Model? 
 
+### Completes ###
 - Writeup README
 	- Docker Instructions
 	- Local Python Instructions
-### Completes ###
+- Add Average Temperature Column.
+- Scrape the Data from the Site.
 - Init EnTempView
 - Get Initial Django/Docker setup going.
 - Init README.md

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ It is a Django app that can be run either locally or with Docker.
 
 ## Docker Instructions
 	Install Docker, Docker-Compose, Python, Pip 
+	`docker-compose up`
+	
+	IF you add additional packages to the README you'll need to rebuild the contianer with: 
+	`docker-compose build`
 	
 ## Local Instructions
 	`pip install -r requirements.txt`

--- a/entemp/urls.py
+++ b/entemp/urls.py
@@ -15,7 +15,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
-from views import entemp_view 
+from entemp.views import entemp_view 
 
 urlpatterns = [
     path('', entemp_view),

--- a/entemp/views.py
+++ b/entemp/views.py
@@ -1,7 +1,37 @@
-from Django.shortcuts import render
-from Django.http import HttpResponse
+from django.shortcuts import render
+from django.http import HttpResponse
+from html.parser import HTMLParser
+import pandas as pd
+import requests
+import math
 
 
 def entemp_view(request):
+
+# Column List ['Year' 'Month' 'Day' 'Maximum T' 'Minimum T' 'Precipitation' 'Snow' 'Snow Depth']
+
+    #Let's not leave this as just a bad redirect.
     source_url = 'https://psl.noaa.gov/boulder/data.daily.html'
-    return HttpResponse ("Hello World" + source_url)
+    html = requests.get(source_url)
+    # This is currently molasses, my guess being that's it's due to lxml vs. html5lib
+    # under the hood. 
+    #TODO: Update below to just use lxml and pass that to pandas.
+    dfs = pd.read_html(io=html.text, match='2021\s+')
+    # Current read_html setup is creating duplicate dataframes for each month
+    # Hence the isnan check.
+    good_frames = [frame for frame in dfs if not math.isnan(frame.iat[0,1])] 
+    full_frame = pd.concat(good_frames, ignore_index=True)
+    #Really interested in what's happening with the indexing here.
+
+    #This is the full data set but it includes the Leap Day which I'm going to assume we don't want.
+    leap_ind = full_frame[((full_frame['Month'] == 2) &( full_frame['Day'] == 29))].index
+    #Welp. Hate everything about this.
+    df = full_frame.drop(leap_ind)
+
+    print('Index', leap_ind)
+    #Add average temp column.
+
+    #Pull Standard Deviation
+    # Add average columns
+    #print(full_frame.columns.values)
+    return HttpResponse(df.to_string())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
 Django==3.2.9
 psycopg2-binary>=2.8
+requests==2.26.0
+pandas==1.3.4
+lxml==4.6.4
+html5lib==1.1
+bs4==0.0.1


### PR DESCRIPTION
What up! This PR:

-Updates the entemp_view to scrape the html data set and prepare a pandas DF without the leap day and an additional "Average Temp" column.
README updates for Docker and  running locally  setup instructions.
-Add `test` to `.gitignore` files
-Adds a number of packages to `requirements.txt` to get the scrapping working within the container.